### PR TITLE
Fix `date` not working on OSX

### DIFF
--- a/event-grid/customevent.json
+++ b/event-grid/customevent.json
@@ -3,7 +3,7 @@
         "id": "'"$RANDOM"'",
         "eventType": "recordInserted",
         "subject": "myapp/vehicles/motorcycles",
-        "eventTime": "'`date --iso-8601=seconds`'",
+        "eventTime": "'`date +%Y-%m-%dT%H:%M:%S%z`'",
         "data":{
             "make": "Ducati",
             "model": "Monster"


### PR DESCRIPTION
"date --iso-8601=seconds" does not work on OSX.  Instead, it's more compatible to be explicit:

https://stackoverflow.com/questions/7216358/date-command-on-os-x-doesnt-have-iso-8601-i-option

On OSX:
➜  ~ date --iso-8601=seconds
date: illegal option -- -
usage: date [-jnRu] [-d dst] [-r seconds] [-t west] [-v[+|-]val[ymwdHMS]] ...
            [-f fmt date | [[[mm]dd]HH]MM[[cc]yy][.ss]] [+format]
➜  ~ date +%Y-%m-%dT%H:%M:%S%z
2017-08-24T15:22:31-0500

On Ubuntu:
thfalgou@sandbox-ubuntu:~$ date --iso-8601=seconds
2017-08-24T20:18:52+00:00