### PR TITLE
DeploymentScript sample showing AzureCLI ACR Import

### DIFF
--- a/deployment-script/deploymentscript-acrimport-cli.bicep
+++ b/deployment-script/deploymentscript-acrimport-cli.bicep
@@ -1,0 +1,91 @@
+@description('The name of the Azure Container Registry')
+param AcrName string
+
+@description('The location to deploy the resources to')
+param location string = resourceGroup().location
+
+@description('How the deployment script should be forced to execute')
+param date string = utcNow()
+
+@description('Version of the Azure CLI to use')
+param azCliVersion string = '2.30.0'
+
+@description('Deployment Script timeout')
+param timeout string = 'PT30M'
+
+@description('The retention period for the deployment script')
+param retention string = 'P1D'
+
+@description('An array of Azure RoleId that are required for the DeploymentScript resource')
+param RbacRolesNeeded array = [
+  'b24988ac-6180-42a0-ab88-20f7382dd24c' //Contributor is needed to import ACR
+]
+
+resource acr 'Microsoft.ContainerRegistry/registries@2021-12-01-preview' = {
+  name: AcrName
+  location: location
+  sku: {
+    name: 'Basic'
+  }
+}
+
+param managedIdName string = 'id-ContainerRegistryImport'
+resource depScriptId 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+  name: managedIdName
+  location: location
+}
+
+resource rbac 'Microsoft.Authorization/roleAssignments@2020-08-01-preview' = [for roleDefId in RbacRolesNeeded: {
+  name: guid(roleDefId, depScriptId.id)
+  scope: acr
+  properties: {
+    roleDefinitionId: resourceId('Microsoft.Authorization/roleDefinitions', roleDefId)
+    principalId: depScriptId.properties.principalId
+    principalType: 'ServicePrincipal'
+  }
+}]
+
+@description('An array of fully qualified images names to import')
+param images array = [
+  'docker.io/bitnami/external-dns:latest'
+]
+
+//@batchSize(1)
+resource createAddCertificate 'Microsoft.Resources/deploymentScripts@2020-10-01' = [for image in images: {
+  name: 'ACR-Import-Certificate-${replace(replace(image,':',''),'/','-')}'
+  location: location
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${depScriptId.id}': {}
+    }
+  }
+  kind: 'AzureCLI'
+  properties: {
+    forceUpdateTag: date
+    azCliVersion: azCliVersion
+    timeout: timeout
+    retentionInterval: retention
+    environmentVariables: [
+      {
+        name: 'AcrName'
+        value: AcrName
+      }
+      {
+        name: 'imageName'
+        value: image
+      }
+    ]
+    scriptContent: '''
+      #!/bin/bash
+      set -e
+
+      echo "Importing Image: $imageName into ACR: $AcrName"
+      az acr import -n $AcrName --source $imageName --force
+    '''
+    cleanupPreference: 'OnSuccess'
+  }
+  dependsOn: [
+    rbac
+  ]
+}]

--- a/deployment-script/deploymentscript-acrimport-cli.json
+++ b/deployment-script/deploymentscript-acrimport-cli.json
@@ -1,0 +1,151 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.4.1318.3566",
+      "templateHash": "14863589965562042491"
+    }
+  },
+  "parameters": {
+    "AcrName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the Azure Container Registry"
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "The location to deploy the resources to"
+      }
+    },
+    "date": {
+      "type": "string",
+      "defaultValue": "[utcNow()]",
+      "metadata": {
+        "description": "How the deployment script should be forced to execute"
+      }
+    },
+    "azCliVersion": {
+      "type": "string",
+      "defaultValue": "2.30.0",
+      "metadata": {
+        "description": "Version of the Azure CLI to use"
+      }
+    },
+    "timeout": {
+      "type": "string",
+      "defaultValue": "PT30M",
+      "metadata": {
+        "description": "Deployment Script timeout"
+      }
+    },
+    "retention": {
+      "type": "string",
+      "defaultValue": "P1D",
+      "metadata": {
+        "description": "The retention period for the deployment script"
+      }
+    },
+    "RbacRolesNeeded": {
+      "type": "array",
+      "defaultValue": [
+        "b24988ac-6180-42a0-ab88-20f7382dd24c"
+      ],
+      "metadata": {
+        "description": "An array of Azure RoleId that are required for the DeploymentScript resource"
+      }
+    },
+    "managedIdName": {
+      "type": "string",
+      "defaultValue": "id-ContainerRegistryImport"
+    },
+    "images": {
+      "type": "array",
+      "defaultValue": [
+        "docker.io/bitnami/external-dns:latest"
+      ],
+      "metadata": {
+        "description": "An array of fully qualified images names to import"
+      }
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.ContainerRegistry/registries",
+      "apiVersion": "2021-12-01-preview",
+      "name": "[parameters('AcrName')]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "Basic"
+      }
+    },
+    {
+      "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+      "apiVersion": "2018-11-30",
+      "name": "[parameters('managedIdName')]",
+      "location": "[parameters('location')]"
+    },
+    {
+      "copy": {
+        "name": "rbac",
+        "count": "[length(parameters('RbacRolesNeeded'))]"
+      },
+      "type": "Microsoft.Authorization/roleAssignments",
+      "apiVersion": "2020-08-01-preview",
+      "scope": "[format('Microsoft.ContainerRegistry/registries/{0}', parameters('AcrName'))]",
+      "name": "[guid(parameters('RbacRolesNeeded')[copyIndex()], resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('managedIdName')))]",
+      "properties": {
+        "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', parameters('RbacRolesNeeded')[copyIndex()])]",
+        "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('managedIdName'))).principalId]",
+        "principalType": "ServicePrincipal"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ContainerRegistry/registries', parameters('AcrName'))]",
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('managedIdName'))]"
+      ]
+    },
+    {
+      "copy": {
+        "name": "createAddCertificate",
+        "count": "[length(parameters('images'))]"
+      },
+      "type": "Microsoft.Resources/deploymentScripts",
+      "apiVersion": "2020-10-01",
+      "name": "[format('ACR-Import-Certificate-{0}', replace(replace(parameters('images')[copyIndex()], ':', ''), '/', '-'))]",
+      "location": "[parameters('location')]",
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "[format('{0}', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('managedIdName')))]": {}
+        }
+      },
+      "kind": "AzureCLI",
+      "properties": {
+        "forceUpdateTag": "[parameters('date')]",
+        "azCliVersion": "[parameters('azCliVersion')]",
+        "timeout": "[parameters('timeout')]",
+        "retentionInterval": "[parameters('retention')]",
+        "environmentVariables": [
+          {
+            "name": "AcrName",
+            "value": "[parameters('AcrName')]"
+          },
+          {
+            "name": "imageName",
+            "value": "[parameters('images')[copyIndex()]]"
+          }
+        ],
+        "scriptContent": "      #!/bin/bash\r\n      set -e\r\n\r\n      echo \"Importing Image: $imageName into ACR: $AcrName\"\r\n      az acr import -n $AcrName --source $imageName --force\r\n    ",
+        "cleanupPreference": "OnSuccess"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('managedIdName'))]",
+        "rbac"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Most of the deployment samples in the azure docs are showing AzurePowershell resource creation.
This sample shows an AzureCLI inline deploymentscript.

It shows the use of ;
- environment variables
- rbac
- identity
- a practical pattern of using a deploymentscript to import container images to ACR.

Once it's in this repo my intention is to Pr the AzureDocs to add the sample link there.